### PR TITLE
fix: default to IME's caller ID so downloads are cached

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -212,7 +212,7 @@ namespace DODownloader
 
             options.SetRangesIfEmpty();
 
-            var factory = new DODownloadFactory(Caller ?? "PSDODownloader");
+            var factory = new DODownloadFactory(Caller ?? "IntuneAppDownload");
             var file = new DOFile(options.Url, ContentId);
 
             DODownload download = null;


### PR DESCRIPTION
Fixes #13