### PR TITLE
feat: sign releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
     tags:
       - v*
   pull_request:
+  workflow_dispatch:
 
 jobs:
   release:
@@ -14,6 +15,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v7.0.0
       - uses: actions/setup-dotnet@v5.4.0
@@ -26,6 +28,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget
       - run: dotnet build --configuration Release
+      - uses: azure/login@v2
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - name: Install AzureSignTool
+        if: ${{ github.event_name != 'pull_request' }}
+        run: dotnet tool install --global AzureSignTool
+      - name: Sign module
+        if: ${{ github.event_name != 'pull_request' }}
+        run: AzureSignTool sign -kvu $KEY_VAULT_URL -kvc $KEY_VAULT_CERT -kvm -tr http://timestamp.acs.microsoft.com -td sha256 -fd sha256 dist/DODownloader.dll
+        env:
+          KEY_VAULT_URL: ${{ vars.KEY_VAULT_URL }}
+          KEY_VAULT_CERT: ${{ vars.KEY_VAULT_CERT }}
       - if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: natescherer/publish-powershell-action@v1.1.1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - run: dotnet tool install --global AzureSignTool
         if: ${{ github.event_name != 'pull_request' }}
-      - run: azuresigntool sign -kvu $env:KEY_VAULT_URL -kvc $env:KEY_VAULT_CERT -kvm -tr http://timestamp.acs.microsoft.com -td sha256 -fd sha256 dist/*
+      - run: azuresigntool sign -kvu $env:KEY_VAULT_URL -kvc $env:KEY_VAULT_CERT -kvm -tr http://timestamp.acs.microsoft.com -td sha256 -fd sha256 dist/*.dll
         if: ${{ github.event_name != 'pull_request' }}
         env:
           KEY_VAULT_URL: ${{ vars.KEY_VAULT_URL }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - run: dotnet tool install --global AzureSignTool
         if: ${{ github.event_name != 'pull_request' }}
-      - run: AzureSignTool sign -kvu $KEY_VAULT_URL -kvc $KEY_VAULT_CERT -kvm -tr http://timestamp.acs.microsoft.com -td sha256 -fd sha256 dist
+      - run: azuresigntool sign -kvu $KEY_VAULT_URL -kvc $KEY_VAULT_CERT -kvm -tr http://timestamp.acs.microsoft.com -td sha256 -fd sha256 dist
         if: ${{ github.event_name != 'pull_request' }}
         env:
           KEY_VAULT_URL: ${{ vars.KEY_VAULT_URL }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,31 +28,31 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nuget
       - run: dotnet build --configuration Release
-      - uses: azure/login@v2
+      - name: Set prerelease version
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        shell: pwsh
+        run: (Get-Content dist/PSDODownloader.psd1) -replace "Prerelease =.+", "Prerelease = '$($env:GITHUB_SHA.Substring(0,7))'" | Set-Content dist/PSDODownloader.psd1
+        
+      - uses: azure/login@v3.0.0
         if: ${{ github.event_name != 'pull_request' }}
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-      - name: Install AzureSignTool
+      - run: dotnet tool install --global AzureSignTool
         if: ${{ github.event_name != 'pull_request' }}
-        run: dotnet tool install --global AzureSignTool
-      - name: Sign module
+      - run: AzureSignTool sign -kvu $KEY_VAULT_URL -kvc $KEY_VAULT_CERT -kvm -tr http://timestamp.acs.microsoft.com -td sha256 -fd sha256 dist
         if: ${{ github.event_name != 'pull_request' }}
-        run: AzureSignTool sign -kvu $KEY_VAULT_URL -kvc $KEY_VAULT_CERT -kvm -tr http://timestamp.acs.microsoft.com -td sha256 -fd sha256 dist/DODownloader.dll
         env:
           KEY_VAULT_URL: ${{ vars.KEY_VAULT_URL }}
           KEY_VAULT_CERT: ${{ vars.KEY_VAULT_CERT }}
+
       - if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: natescherer/publish-powershell-action@v1.1.1
         with:
           token: ${{ secrets.PS_GALLERY_KEY }}
           target: gallery
           path: dist
-      - name: Set prerelease version
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        shell: pwsh
-        run: (Get-Content dist/PSDODownloader.psd1) -replace "Prerelease =.+", "Prerelease = '$($env:GITHUB_SHA.Substring(0,7))'" | Set-Content dist/PSDODownloader.psd1
       - uses: natescherer/publish-powershell-action@v1.1.1
         with:
           token: ${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - run: dotnet tool install --global AzureSignTool
         if: ${{ github.event_name != 'pull_request' }}
-      - run: azuresigntool sign -kvu $KEY_VAULT_URL -kvc $KEY_VAULT_CERT -kvm -tr http://timestamp.acs.microsoft.com -td sha256 -fd sha256 dist
+      - run: azuresigntool sign -kvu $env:KEY_VAULT_URL -kvc $env:KEY_VAULT_CERT -kvm -tr http://timestamp.acs.microsoft.com -td sha256 -fd sha256 dist/DODownloader.dll
         if: ${{ github.event_name != 'pull_request' }}
         env:
           KEY_VAULT_URL: ${{ vars.KEY_VAULT_URL }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - run: dotnet tool install --global AzureSignTool
         if: ${{ github.event_name != 'pull_request' }}
-      - run: azuresigntool sign -kvu $env:KEY_VAULT_URL -kvc $env:KEY_VAULT_CERT -kvm -tr http://timestamp.acs.microsoft.com -td sha256 -fd sha256 dist/DODownloader.dll
+      - run: azuresigntool sign -kvu $env:KEY_VAULT_URL -kvc $env:KEY_VAULT_CERT -kvm -tr http://timestamp.acs.microsoft.com -td sha256 -fd sha256 dist/*
         if: ${{ github.event_name != 'pull_request' }}
         env:
           KEY_VAULT_URL: ${{ vars.KEY_VAULT_URL }}


### PR DESCRIPTION
## Summary
Enhanced the release workflow with code signing capabilities and improved workflow triggering options.

## Key Changes
- **Workflow Dispatch**: Added `workflow_dispatch` trigger to allow manual execution of the release workflow
- **Code Signing**: Integrated Azure-based code signing for the DODownloader.dll module:
  - Added `id-token: write` permission for OIDC authentication with Azure
  - Implemented Azure login step using federated credentials (client-id, tenant-id, subscription-id)
  - Added AzureSignTool installation and execution to sign the built DLL
  - Signing is conditionally executed only for tag and manual dispatch events (skipped for pull requests)
- **Configuration**: Leverages GitHub variables for Azure Key Vault URL and certificate name

## Implementation Details
- The signing step uses SHA256 hashing and Microsoft's timestamp authority for compliance
- All signing-related steps are guarded with `if: ${{ github.event_name != 'pull_request' }}` to prevent unnecessary operations during PR validation
- Azure authentication uses OpenID Connect (OIDC) for secure, keyless authentication instead of stored credentials

https://claude.ai/code/session_01CCaSuw4Gy16z7mqZ66LosK