### PR TITLE
fix: sign the module manifest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - run: dotnet tool install --global AzureSignTool
         if: ${{ github.event_name != 'pull_request' }}
-      - run: azuresigntool sign -kvu $env:KEY_VAULT_URL -kvc $env:KEY_VAULT_CERT -kvm -tr http://timestamp.acs.microsoft.com -td sha256 -fd sha256 dist/*.dll
+      - run: azuresigntool sign -kvu $env:KEY_VAULT_URL -kvc $env:KEY_VAULT_CERT -kvm -tr http://timestamp.acs.microsoft.com -td sha256 -fd sha256 dist/*.dll dist/*.psd1
         if: ${{ github.event_name != 'pull_request' }}
         env:
           KEY_VAULT_URL: ${{ vars.KEY_VAULT_URL }}


### PR DESCRIPTION
## Summary

Follow-up to #25: the release workflow signed `DODownloader.dll` but not `PSDODownloader.psd1`. This adds the manifest to the AzureSignTool invocation so it's Authenticode-signed (via the PowerShell SIP on the Windows runner) alongside the assembly.

Change is a single line in `.github/workflows/release.yaml`:

```diff
-  ... -td sha256 -fd sha256 dist/*.dll
+  ... -td sha256 -fd sha256 dist/*.dll dist/*.psd1
```

The prerelease-version rewrite still runs before the sign step, so the manifest signature stays valid.

## Testing

Verified via `workflow_dispatch`:

```
=> File: dist\DODownloader.dll         Signing completed successfully.
=> File: dist\PSDODownloader.psd1      Signing completed successfully.
Successful operations: 2
Failed operations: 0
```

Both files signed against the Key Vault `code-signing` cert, and the signed module published to GitHub Packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCaSuw4Gy16z7mqZ66LosK)_